### PR TITLE
Format the clojure threading code a little better

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ Clojure's threading macro is a prefix operator, which means it is less readable 
 
 CLOJURE (prefix): 
 
-    (-> (list (-> (-> id3 (hash-ref 'genre "unknown")) normalise-field)
-              (-> (-> id3 (hash-ref 'track "0")) normalise-field)
-              (-> (-> id3 (hash-ref 'artist "unknown")) normalise-field)
-              (-> (-> id3 (hash-ref 'title "unknown")) normalise-field)) (string-join "."))
+    (-> (list (-> id3 (hash-ref 'genre "unknown") normalise-field)
+              (-> id3 (hash-ref 'track "0") normalise-field)
+              (-> id3 (hash-ref 'artist "unknown") normalise-field)
+              (-> id3 (hash-ref 'title "unknown") normalise-field))
+        (string-join "."))
 
 FLUENT (infix):
 


### PR DESCRIPTION
- The `->` operator in clojure accepts any number of arguments, so `(-> (-> a b) c)` is the same as `(-> a b c)`.
- Putting the arguments to the outer `->` form on separate lines makes it easier to see the steps of the outer threading expression.